### PR TITLE
fix: `@import` statements without a file extension are now resolved correctly

### DIFF
--- a/src/v4/core/parser/imports.ts
+++ b/src/v4/core/parser/imports.ts
@@ -24,6 +24,11 @@ const URL_IMPORT_REGEX = /^url\(['"]?([^'"]+)['"]?\)/;
 const STRING_IMPORT_REGEX = /^['"]([^'"]+)['"]/;
 
 /**
+ * File extension for CSS `@import` statements, added if not provided.
+ */
+const IMPORT_FILE_EXTENSION = '.css'
+
+/**
  * Resolves all `@import` statements in a PostCSS AST recursively
  *
  * This function performs graceful error handling by design:
@@ -74,7 +79,8 @@ export async function resolveImports(
   // Process imports in parallel for better performance
   const results = await Promise.allSettled(
     importsToProcess.map(async ({ atRule, importPath }) => {
-      const resolvedPath = resolve(basePath, importPath);
+      const importPathWithExtension = importPath.endsWith(IMPORT_FILE_EXTENSION) ? importPath : `${importPath}${IMPORT_FILE_EXTENSION}`;
+      const resolvedPath = resolve(basePath, importPathWithExtension);
 
       // Skip if already processed (circular import prevention)
       if (processedFiles.has(resolvedPath)) {

--- a/src/v4/core/parser/imports.ts
+++ b/src/v4/core/parser/imports.ts
@@ -24,9 +24,38 @@ const URL_IMPORT_REGEX = /^url\(['"]?([^'"]+)['"]?\)/;
 const STRING_IMPORT_REGEX = /^['"]([^'"]+)['"]/;
 
 /**
- * File extension for CSS `@import` statements, added if not provided.
+ * Relative import path prefixes for local file resolution
  */
-const IMPORT_FILE_EXTENSION = '.css'
+const RELATIVE_IMPORT_PREFIXES = ['./', '../'] as const;
+
+/**
+ * File extension for CSS `@import` statements, added if not provided
+ */
+const CSS_FILE_EXTENSION = '.css'
+
+/**
+ * Checks if an import path is a relative file import (not a bare package specifier)
+ *
+ * @param importPath - The import path to check
+ * @returns True if the path is relative (starts with ./ or ../)
+ */
+function isRelativeImport(importPath: string): boolean {
+  return RELATIVE_IMPORT_PREFIXES.some((prefix) => importPath.startsWith(prefix));
+}
+
+/**
+ * Ensures a relative import path has the provided file extension
+ *
+ * @param importPath - The original import path
+ * @param extension - The file extension to add, if missing - defaults to .css
+ * @returns The path with extension if relative and missing, otherwise unchanged
+ */
+function normalizeImportPath(importPath: string, extension: string = CSS_FILE_EXTENSION): string {
+  if (isRelativeImport(importPath) && !importPath.endsWith(extension)) {
+    return `${importPath}${extension}`;
+  }
+  return importPath;
+}
 
 /**
  * Resolves all `@import` statements in a PostCSS AST recursively
@@ -79,7 +108,7 @@ export async function resolveImports(
   // Process imports in parallel for better performance
   const results = await Promise.allSettled(
     importsToProcess.map(async ({ atRule, importPath }) => {
-      const importPathWithExtension = importPath.endsWith(IMPORT_FILE_EXTENSION) ? importPath : `${importPath}${IMPORT_FILE_EXTENSION}`;
+      const importPathWithExtension = normalizeImportPath(importPath);
       const resolvedPath = resolve(basePath, importPathWithExtension);
 
       // Skip if already processed (circular import prevention)

--- a/test/v4/core/imports_test.ts
+++ b/test/v4/core/imports_test.ts
@@ -3,7 +3,7 @@
  * Tests recursive @import resolution, circular import prevention, and error handling
  */
 
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -174,6 +174,31 @@ describe('resolveImports - Nested imports', () => {
     expect(files).toHaveLength(1);
   });
 });
+
+describe('resolveImports - bare packages', () => {
+  test('resolves bare package imports', async () => {
+    // Stub for a bare package import
+    await writeFile(join(tempDir, 'tw-animate-css'), '--color: red;');
+
+    const root = postcss.parse('@import "tw-animate-css";');
+    const imports = await resolveImports(root, tempDir, new Set());
+
+    expect(imports).toHaveLength(1);
+    expect(imports[0]).toEndWith('tw-animate-css')
+  })
+
+  test('resolves bare package import with leading @', async () => {
+    // Stub for a bare package import
+    await mkdir(join(tempDir, '@bprogress', 'core'), { recursive: true })
+    await writeFile(join(tempDir, '@bprogress', 'core', 'css'), '--color: red;');
+
+    const root = postcss.parse('@import "@bprogress/core/css";');
+    const imports = await resolveImports(root, tempDir, new Set());
+
+    expect(imports).toHaveLength(1);
+    expect(imports[0]).toEndWith('@bprogress/core/css')
+  })
+})
 
 describe('resolveImports - Circular import prevention', () => {
   test('prevents circular imports using processedFiles set', async () => {

--- a/test/v4/fixtures/imports_level2.css
+++ b/test/v4/fixtures/imports_level2.css
@@ -3,7 +3,7 @@
  * Tests recursive import resolution
  */
 
-@import './imports_level3.css';
+@import './imports_level3';
 
 @theme {
   /* Level 2 theme additions */

--- a/test/v4/fixtures/main.css
+++ b/test/v4/fixtures/main.css
@@ -7,7 +7,7 @@
 @import './base_theme.css';
 @import './dark_mode.css';
 @import './custom_themes.css';
-@import './media_queries.css';
+@import './media_queries';
 @import './overrides.css';
 @import './imports_level1.css';
 


### PR DESCRIPTION
## Description

See #14. I've tweaked the existing test fixtures slightly to include the error rather than adding a new fixture for it. 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] CI/CD or tooling change

## Changes Made

- `@imports` without a file extension are now resolved correctly as `.css` files

## Testing

<!-- Describe the tests you've run -->

- [x] All existing tests pass (`bun test`)
- [ ] New tests added (if applicable)
- [x] Manually tested locally
- [ ] Built successfully (`bun run build`)
- [x] Linting passes (`bun run lint`)

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CHANGELOG.md (if needed)
- [ ] Added/updated JSDoc comments
- [ ] Updated ARCHITECTURE.md (if needed)

## Related Issues

Closes #14
